### PR TITLE
Skip unknown services

### DIFF
--- a/src/Service/PUDOFactory.php
+++ b/src/Service/PUDOFactory.php
@@ -51,7 +51,11 @@ class PUDOFactory
     {
         $info = new AdditionalInfo();
         foreach (explode(';', (string) $xml->SERVICE_PUDO) as $service) {
-            $info->services[] = Service::byValue($service);
+            try {
+                $info->services[] = Service::byValue($service);
+            } catch (\InvalidArgumentException $e) {
+                // NOP, do not fail hard for new services
+            }
         }
         $info->wheelchairAccessible = 'true' === (string) $xml->HANDICAPE;
         $info->parking = 'true' === (string) $xml->PARKING;

--- a/tests/fixtures/full_pudo.xml
+++ b/tests/fixtures/full_pudo.xml
@@ -5,7 +5,7 @@
             <PUDO_ID>PL15625</PUDO_ID>
             <ORDER>1</ORDER>
             <PUDO_TYPE>100</PUDO_TYPE>
-            <SERVICE_PUDO>100;200;201</SERVICE_PUDO>
+            <SERVICE_PUDO>100;200;201;THIS_DOES_NOT_EXIST</SERVICE_PUDO>
             <LANGUAGE>PL</LANGUAGE>
             <ADDRESS1>Na Szaniec 21 box 4</ADDRESS1>
             <ADDRESS2>ADDRESS2</ADDRESS2>


### PR DESCRIPTION
The command started failing due to the new service `10001`. As I have no clue what that is we've decided to skip services not listed in the enum and let the community add them as needed.