### PR TITLE
Add streaming PUDOList support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ instance of `\Answear\DpdPlPickupServicesBundle\Service\ConfigProvider` object.
 Usage
 -----
 
-DPD's API is available through the `Answear\DpdPlPickupServicesBundle\Service\PUDOList`
-that is automatically registered in your Symfony application's DI container. PUDO items
+DPD's API is available through two main services:
+
+1. `Answear\DpdPlPickupServicesBundle\Service\PUDOList` - returns all PUDO items at once
+2. `Answear\DpdPlPickupServicesBundle\Service\PUDOListStreaming` - streams PUDO items one by one
+
+Both services are automatically registered in your Symfony application's DI container. PUDO items
 are returned to you as `Answear\DpdPlPickupServicesBundle\ValueObject\PUDO` objects.
 
 Final notes

--- a/src/Service/AbstractPUDOList.php
+++ b/src/Service/AbstractPUDOList.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Answear\DpdPlPickupServicesBundle\Service;
+
+use Answear\DpdPlPickupServicesBundle\Exception\ServiceException;
+use Answear\DpdPlPickupServicesBundle\ValueObject\Coordinates;
+use Answear\DpdPlPickupServicesBundle\ValueObject\PUDO;
+
+abstract class AbstractPUDOList
+{
+    /**
+     * @return iterable<PUDO>
+     *
+     * @throws ServiceException
+     */
+    public function byAddress(string $zipCode, string $city, ?string $address = null): iterable
+    {
+        $params = [
+            'requestID' => \uniqid('', true),
+            'city' => $city,
+            'zipCode' => $zipCode,
+            'servicePudo_display' => 1,
+        ];
+        if (null !== $address) {
+            $params['address'] = $address;
+        }
+
+        return $this->request('list/byaddress', $params);
+    }
+
+    /**
+     * @return iterable<PUDO>
+     *
+     * @throws ServiceException
+     */
+    public function byCountry(string $countryCode): iterable
+    {
+        return $this->request('list/bycountry', ['countryCode' => $countryCode]);
+    }
+
+    /**
+     * @throws ServiceException
+     */
+    public function byId(string $id): ?PUDO
+    {
+        $generator = $this->request('details', ['pudoId' => $id]);
+
+        foreach ($generator as $pudo) {
+            return $pudo;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return iterable<PUDO>
+     *
+     * @throws ServiceException
+     */
+    public function byLatLng(Coordinates $coordinates, int $distance): iterable
+    {
+        return $this->request(
+            'list/bylonglat',
+            [
+                'requestID' => \uniqid('', true),
+                'latitude' => $coordinates->latitude,
+                'longitude' => $coordinates->longitude,
+                'max_distance_search' => $distance,
+            ]
+        );
+    }
+
+    
+    abstract protected function request(string $endpoint, array $params): iterable;
+}

--- a/src/Service/PUDOList.php
+++ b/src/Service/PUDOList.php
@@ -11,7 +11,7 @@ use Answear\DpdPlPickupServicesBundle\ValueObject\PUDO;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 
-class PUDOList
+class PUDOList extends AbstractPUDOList
 {
     private ClientInterface $client;
 
@@ -31,66 +31,8 @@ class PUDOList
 
     /**
      * @return PUDO[]
-     *
-     * @throws ServiceException
      */
-    public function byAddress(string $zipCode, string $city, ?string $address = null): array
-    {
-        $params = [
-            'requestID' => \uniqid('', true),
-            'city' => $city,
-            'zipCode' => $zipCode,
-            'servicePudo_display' => 1,
-        ];
-        if (null !== $address) {
-            $params['address'] = $address;
-        }
-
-        return $this->request('list/byaddress', $params);
-    }
-
-    /**
-     * @return PUDO[]
-     *
-     * @throws ServiceException
-     */
-    public function byCountry(string $countryCode): array
-    {
-        return $this->request('list/bycountry', ['countryCode' => $countryCode]);
-    }
-
-    /**
-     * @throws ServiceException
-     */
-    public function byId(string $id): ?PUDO
-    {
-        $result = $this->request('details', ['pudoId' => $id]);
-
-        return 1 === \count($result) ? \reset($result) : null;
-    }
-
-    /**
-     * @return PUDO[]
-     *
-     * @throws ServiceException
-     */
-    public function byLatLng(Coordinates $coordinates, int $distance): array
-    {
-        return $this->request(
-            'list/bylonglat',
-            [
-                'requestID' => \uniqid('', true),
-                'latitude' => $coordinates->latitude,
-                'longitude' => $coordinates->longitude,
-                'max_distance_search' => $distance,
-            ]
-        );
-    }
-
-    /**
-     * @return PUDO[]
-     */
-    private function request(string $endpoint, array $params): array
+    protected function request(string $endpoint, array $params): iterable
     {
         $params['key'] = $this->configProvider->key;
 

--- a/src/Service/PUDOListStreaming.php
+++ b/src/Service/PUDOListStreaming.php
@@ -11,7 +11,7 @@ use Answear\DpdPlPickupServicesBundle\ValueObject\PUDO;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 
-class PUDOListStreaming
+class PUDOListStreaming extends AbstractPUDOList
 {
     private ClientInterface $client;
 
@@ -32,70 +32,8 @@ class PUDOListStreaming
 
     /**
      * @return iterable<PUDO>
-     *
-     * @throws ServiceException
      */
-    public function byAddress(string $zipCode, string $city, ?string $address = null): iterable
-    {
-        $params = [
-            'requestID' => \uniqid('', true),
-            'city' => $city,
-            'zipCode' => $zipCode,
-            'servicePudo_display' => 1,
-        ];
-        if (null !== $address) {
-            $params['address'] = $address;
-        }
-
-        return $this->request('list/byaddress', $params);
-    }
-
-    /**
-     * @return iterable<PUDO>
-     *
-     * @throws ServiceException
-     */
-    public function byCountry(string $countryCode): iterable
-    {
-        return $this->request('list/bycountry', ['countryCode' => $countryCode]);
-    }
-
-    /**
-     * @throws ServiceException
-     */
-    public function byId(string $id): ?PUDO
-    {
-        $generator = $this->request('details', ['pudoId' => $id]);
-
-        foreach ($generator as $pudo) {
-            return $pudo;
-        }
-
-        return null;
-    }
-
-    /**
-     * @return iterable<PUDO>
-     *
-     * @throws ServiceException
-     */
-    public function byLatLng(Coordinates $coordinates, int $distance): iterable
-    {
-        return $this->request(
-            'list/bylonglat',
-            [
-                'requestID' => \uniqid('', true),
-                'latitude' => $coordinates->latitude,
-                'longitude' => $coordinates->longitude,
-                'max_distance_search' => $distance,
-            ]
-        );
-    }
-
-    /**
-     * @return iterable<PUDO>
-     */
-    private function request(string $endpoint, array $params): iterable
+    protected function request(string $endpoint, array $params): iterable
     {
         $params['key'] = $this->configProvider->key;
 

--- a/src/Service/PUDOListStreaming.php
+++ b/src/Service/PUDOListStreaming.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Answear\DpdPlPickupServicesBundle\Service;
+
+use Answear\DpdPlPickupServicesBundle\Exception\MalformedResponseException;
+use Answear\DpdPlPickupServicesBundle\Exception\ServiceException;
+use Answear\DpdPlPickupServicesBundle\ValueObject\Coordinates;
+use Answear\DpdPlPickupServicesBundle\ValueObject\PUDO;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+
+class PUDOListStreaming
+{
+    private ClientInterface $client;
+
+    public function __construct(
+        private PUDOFactory $PUDOFactory,
+        private ConfigProvider $configProvider,
+        ?ClientInterface $client = null,
+    ) {
+        $this->client = $client ?? new Client(
+            [
+                'base_uri' => $configProvider->url,
+                'http_errors' => false,
+                'timeout' => $configProvider->requestTimeout,
+                'stream' => true,
+            ]
+        );
+    }
+
+    /**
+     * @return iterable<PUDO>
+     *
+     * @throws ServiceException
+     */
+    public function byAddress(string $zipCode, string $city, ?string $address = null): iterable
+    {
+        $params = [
+            'requestID' => \uniqid('', true),
+            'city' => $city,
+            'zipCode' => $zipCode,
+            'servicePudo_display' => 1,
+        ];
+        if (null !== $address) {
+            $params['address'] = $address;
+        }
+
+        return $this->request('list/byaddress', $params);
+    }
+
+    /**
+     * @return iterable<PUDO>
+     *
+     * @throws ServiceException
+     */
+    public function byCountry(string $countryCode): iterable
+    {
+        return $this->request('list/bycountry', ['countryCode' => $countryCode]);
+    }
+
+    /**
+     * @throws ServiceException
+     */
+    public function byId(string $id): ?PUDO
+    {
+        $generator = $this->request('details', ['pudoId' => $id]);
+
+        foreach ($generator as $pudo) {
+            return $pudo;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return iterable<PUDO>
+     *
+     * @throws ServiceException
+     */
+    public function byLatLng(Coordinates $coordinates, int $distance): iterable
+    {
+        return $this->request(
+            'list/bylonglat',
+            [
+                'requestID' => \uniqid('', true),
+                'latitude' => $coordinates->latitude,
+                'longitude' => $coordinates->longitude,
+                'max_distance_search' => $distance,
+            ]
+        );
+    }
+
+    /**
+     * @return iterable<PUDO>
+     */
+    private function request(string $endpoint, array $params): iterable
+    {
+        $params['key'] = $this->configProvider->key;
+
+        $response = $this->client->request('GET', $endpoint, ['query' => $params]);
+        $stream = $response->getBody();
+
+        $xmlContent = '';
+        while (!$stream->eof()) {
+            $xmlContent .= $stream->read(8192);
+        }
+
+        $xml = @\simplexml_load_string($xmlContent);
+        if (false === $xml) {
+            throw new MalformedResponseException($xmlContent);
+        }
+
+        if ($xml->ERROR) {
+            throw new ServiceException((string) $xml->ERROR->VALUE, (int) $xml->ERROR['code']);
+        }
+
+        $reader = new \XMLReader();
+        $reader->XML($xmlContent);
+
+        while ($reader->read()) {
+            if ($reader->nodeType === \XMLReader::ELEMENT && $reader->name === 'PUDO_ITEM') {
+                $pudoXml = $reader->readOuterXml();
+                $pudoElement = @\simplexml_load_string($pudoXml);
+
+                if (false !== $pudoElement) {
+                    yield $this->PUDOFactory->fromXmlElement($pudoElement);
+                }
+            }
+        }
+
+        $reader->close();
+    }
+}

--- a/tests/Service/PUDOListStreamingTest.php
+++ b/tests/Service/PUDOListStreamingTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Answear\DpdPlPickupServicesBundle\Tests\Service;
+
+use Answear\DpdPlPickupServicesBundle\DependencyInjection\Configuration;
+use Answear\DpdPlPickupServicesBundle\Exception\MalformedResponseException;
+use Answear\DpdPlPickupServicesBundle\Exception\ServiceException;
+use Answear\DpdPlPickupServicesBundle\Service\ConfigProvider;
+use Answear\DpdPlPickupServicesBundle\Service\PUDOFactory;
+use Answear\DpdPlPickupServicesBundle\Service\PUDOListStreaming;
+use Answear\DpdPlPickupServicesBundle\ValueObject\Coordinates;
+use Answear\DpdPlPickupServicesBundle\ValueObject\PUDO;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PUDOListStreamingTest extends TestCase
+{
+    private array $guzzleHistory;
+    private MockHandler $guzzleHandler;
+    private PUDOListStreaming $PUDOListStreaming;
+
+    public function setUp(): void
+    {
+        $this->guzzleHandler = new MockHandler();
+        $handlerStack = HandlerStack::create($this->guzzleHandler);
+
+        $this->guzzleHistory = [];
+        $history = Middleware::history($this->guzzleHistory);
+        $handlerStack->push($history);
+
+        $this->PUDOListStreaming = new PUDOListStreaming(
+            new PUDOFactory(),
+            new ConfigProvider('key', 'url', 10),
+            new Client(
+                [
+                    'base_uri' => Configuration::API_URL,
+                    'handler' => $handlerStack,
+                    'http_errors' => false,
+                    'stream' => true,
+                ]
+            )
+        );
+    }
+
+    #[Test]
+    public function byAddress(): void
+    {
+        $this->guzzleHandler->append(
+            new Response(
+                200,
+                [],
+                file_get_contents(__DIR__ . '/../fixtures/three_results.xml')
+            )
+        );
+
+        $results = $this->PUDOListStreaming->byAddress('31-564', 'Kraków', 'Aleja Pokoju 18');
+        $this->assertThreeResults($results);
+
+        /** @var Request $request */
+        $request = $this->guzzleHistory[0]['request'];
+        self::assertSame('/api/pudo/list/byaddress', $request->getUri()->getPath());
+        \parse_str($request->getUri()->getQuery(), $query);
+        self::assertArrayHasKey('requestID', $query);
+        self::assertArrayHasKey('key', $query);
+        self::assertSame('Kraków', $query['city']);
+        self::assertSame('31-564', $query['zipCode']);
+        self::assertSame('Aleja Pokoju 18', $query['address']);
+        self::assertSame('1', $query['servicePudo_display']);
+    }
+
+    #[Test]
+    public function byCountry(): void
+    {
+        $this->guzzleHandler->append(
+            new Response(
+                200,
+                [],
+                file_get_contents(__DIR__ . '/../fixtures/three_results.xml')
+            )
+        );
+
+        $results = $this->PUDOListStreaming->byCountry('POL');
+        $this->assertThreeResults($results);
+
+        /** @var Request $request */
+        $request = $this->guzzleHistory[0]['request'];
+        self::assertSame('/api/pudo/list/bycountry', $request->getUri()->getPath());
+        \parse_str($request->getUri()->getQuery(), $query);
+        self::assertArrayHasKey('key', $query);
+        self::assertSame('POL', $query['countryCode']);
+    }
+
+    #[Test]
+    public function byCountryNoResults(): void
+    {
+        $this->guzzleHandler->append(
+            new Response(
+                200,
+                [],
+                file_get_contents(__DIR__ . '/../fixtures/no_items.xml')
+            )
+        );
+
+        $results = iterator_to_array($this->PUDOListStreaming->byCountry('POL'));
+        self::assertCount(0, $results);
+    }
+
+    #[Test]
+    public function byId(): void
+    {
+        $this->guzzleHandler->append(
+            new Response(
+                200,
+                [],
+                file_get_contents(__DIR__ . '/../fixtures/full_pudo.xml')
+            )
+        );
+
+        $pudo = $this->PUDOListStreaming->byId('PL15625');
+        self::assertInstanceOf(PUDO::class, $pudo);
+        self::assertSame('PL15625', $pudo->id);
+
+        /** @var Request $request */
+        $request = $this->guzzleHistory[0]['request'];
+        self::assertSame('/api/pudo/details', $request->getUri()->getPath());
+        \parse_str($request->getUri()->getQuery(), $query);
+        self::assertArrayHasKey('key', $query);
+        self::assertSame('PL15625', $query['pudoId']);
+    }
+
+    #[Test]
+    public function byIdNoResult(): void
+    {
+        $this->guzzleHandler->append(
+            new Response(
+                200,
+                [],
+                file_get_contents(__DIR__ . '/../fixtures/no_items.xml')
+            )
+        );
+
+        self::assertNull($this->PUDOListStreaming->byId('PL15625'));
+    }
+
+    #[Test]
+    public function byLatLng(): void
+    {
+        $this->guzzleHandler->append(
+            new Response(
+                200,
+                [],
+                file_get_contents(__DIR__ . '/../fixtures/three_results.xml')
+            )
+        );
+
+        $results = $this->PUDOListStreaming->byLatLng(new Coordinates(50.061389, 19.937222), 100);
+        $this->assertThreeResults($results);
+
+        /** @var Request $request */
+        $request = $this->guzzleHistory[0]['request'];
+        self::assertSame('/api/pudo/list/bylonglat', $request->getUri()->getPath());
+        \parse_str($request->getUri()->getQuery(), $query);
+        self::assertArrayHasKey('requestID', $query);
+        self::assertArrayHasKey('key', $query);
+        self::assertSame('50.061389', $query['latitude']);
+        self::assertSame('19.937222', $query['longitude']);
+        self::assertSame('100', $query['max_distance_search']);
+    }
+
+    #[Test]
+    public function apiError(): void
+    {
+        $this->guzzleHandler->append(
+            new Response(
+                401,
+                [],
+                file_get_contents(__DIR__ . '/../fixtures/auth_error.xml')
+            )
+        );
+
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionCode(314);
+        $this->expectExceptionMessage('Podana wartość key jest niepoprawna. Klucz nie istnieje lub jest nieaktywny.');
+
+        $this->PUDOListStreaming->byId('PL15625');
+    }
+
+    #[Test]
+    public function noXmlInResponse(): void
+    {
+        $this->guzzleHandler->append(new Response(500, [], 'Internal Server Error'));
+
+        $this->expectExceptionObject(new MalformedResponseException('Internal Server Error'));
+        $this->PUDOListStreaming->byId('PL15625');
+    }
+
+    private function assertThreeResults(iterable $results): void
+    {
+        $resultsArray = iterator_to_array($results);
+        self::assertCount(3, $resultsArray);
+        $expected = ['PL11011', 'PL11016', 'PL11021'];
+        foreach ($resultsArray as $i => $result) {
+            self::assertInstanceOf(PUDO::class, $result);
+            self::assertSame($expected[$i], $result->id);
+        }
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces a new class `PUDOListStreaming`, an optimized version of `PUDOList`, designed to handle large XML responses from the DPD Pickup Services API in a memory-efficient streaming manner.

### Details

- Uses Guzzle’s streaming mode `('stream' => true)` to avoid loading entire responses into memory.
- Parses XML incrementally via `XMLReader`, yielding `PUDO` objects one by one instead of building large arrays.
- Maintains the same public interface and method signatures as `PUDOList (byAddress, byCountry, byId, byLatLng)`.
- Ensures backward compatibility and exception handling (`MalformedResponseException`, `ServiceException`) consistent with the original implementation.

### Motivation

The previous implementation (`PUDOList`) fully loaded and parsed XML in memory, which could cause high memory usage for large PUDO datasets.
The new streaming-based version significantly reduces memory footprint and improves scalability for large responses.